### PR TITLE
Patch for Woocommerce Check when active

### DIFF
--- a/classes/Services/Blocks.php
+++ b/classes/Services/Blocks.php
@@ -30,17 +30,17 @@ class Blocks {
 	}
 
 	public function get_disabled_blocks() {
-		$blocks = get_option('gutenberg-blocks-disabled');
+		$blocks = get_option( 'gutenberg-blocks-disabled' );
 
-    // Disable WooCommerce blocks if Woo is not active
-    if ( ! class_exists( 'WooCommerce' ) ) {
-      foreach( $this->registered_blocks as $block ) {
+		// Disable WooCommerce blocks if Woo is not active
+		if ( ! class_exists( 'WooCommerce' ) && isset( $this->registered_blocks ) ) {
+			foreach ( $this->registered_blocks as $block ) {
 
-				if( $block['category'] == "woo" ) {
+				if ( $block['category'] == "woo" ) {
 					$blocks[] = $block['id'];
 				}
-      }
-    }
+			}
+		}
 
 		if ( $blocks == "" ) {
 			return array();


### PR DESCRIPTION
Adding an additional conditional check, if the variable is set, otherwise errors out on null when woocommerce is active.

```php
Warning: Invalid argument supplied for foreach() in /sites/test/wp-content/plugins/advanced-gutenberg-blocks/classes/Services/Blocks.php on line 37
--
1 | 0.0015 | 366728 | {main}( ) | .../server.php:0
2 | 0.0027 | 393488 | require( '/sites/test/wp-admin/post.php' ) | .../server.php:120
3 | 0.1070 | 6551336 | apply_filters( ) | .../post.php:155
4 | 0.1070 | 6551736 | WP_Hook->apply_filters( ) | .../plugin.php:203
5 | 0.1070 | 6553240 | gutenberg_init( ) | .../class-wp-hook.php:286
6 | 0.1072 | 6555712 | require_once( '/sites/test/wp-admin/admin-header.php' ) | .../gutenberg.php:172
7 | 0.1081 | 6565920 | do_action( ) | .../admin-header.php:97
8 | 0.1081 | 6566296 | WP_Hook->do_action( ) | .../plugin.php:453
9 | 0.1081 | 6566296 | WP_Hook->apply_filters( ) | .../class-wp-hook.php:310
10 | 0.1121 | 6603664 | gutenberg_editor_scripts_and_styles( ) | .../class-wp-hook.php:286
11 | 0.1764 | 7683656 | do_action( ) | .../client-assets.php:1087
12 | 0.1764 | 7684032 | WP_Hook->do_action( ) | .../plugin.php:453
13 | 0.1764 | 7684032 | WP_Hook->apply_filters( ) | .../class-wp-hook.php:310
14 | 0.1764 | 7685136 | AdvancedGutenbergBlocks\WP\Gutenberg->editor_assets( ) | .../class-wp-hook.php:286
15 | 0.1769 | 7688320 | AdvancedGutenbergBlocks\Services\Blocks->get_disabled_blocks_js( ) | .../Gutenberg.php:76
16 | 0.1769 | 7688320 | AdvancedGutenbergBlocks\Services\Blocks->get_disabled_blocks( ) | .../Blocks.php:54
```