### PR TITLE
Escape the HTML output for the code block

### DIFF
--- a/public/templates/code.php
+++ b/public/templates/code.php
@@ -11,7 +11,7 @@
     class="wp-block-advanced-gutenberg-blocks-code__source" 
     name="codemirror-<?php echo $rand; ?>" 
     id="codemirror-<?php echo $rand; ?>"
-  ><?php echo ( $attributes['source'] ); ?></textarea>
+  ><?php echo esc_html( $attributes['source'] ); ?></textarea>
   <script>
     CodeMirror.fromTextArea( document.getElementById('codemirror-<?php echo $rand; ?>'), {
       mode: '<?php echo $lang_mode; ?>',


### PR DESCRIPTION
Not having this can break so many things. e.g. if you enter </textarea> it won't show any code after, and the tags will be unbalanced.