### PR TITLE
Added support for new languages: TypeScript and JSON

### DIFF
--- a/classes/Blocks/Code.php
+++ b/classes/Blocks/Code.php
@@ -248,6 +248,7 @@ class Code {
 		$lang_slug = $language;
 		$lang_label = $languages[$key]['label'];
 		$lang_mode = $languages[$key]['mode'];
+		$lang_mime = $languages[$key]['mime'];
 
 		// Get Marked text
 		$mark_text = '';
@@ -292,6 +293,8 @@ class Code {
 			array( 'slug' => "css", 				'mode' => 'css', 				'label' => 'CSS' ),
 			array( 'slug' => "php", 				'mode' => 'php', 				'label' => 'PHP' ),
 			array( 'slug' => "js", 					'mode' => 'javascript', 'label' => 'JS' ),
+			array( 'slug' => "ts", 					'mode' => 'javascript',   'mime' => 'application/typescript',   'label' => 'TypeScript' ),
+			array( 'slug' => "json", 				'mode' => 'javascript',   'mime' => 'application/json',   'label' => 'JSON' ),
 			array( 'slug' => "jsx", 				'mode' => 'jsx', 				'label' => 'JSX' ),
 			array( 'slug' => "xml", 				'mode' => 'xml', 				'label' => 'XML' ),
 			array( 'slug' => "sass", 	 			'mode' => 'sass', 			'label' => 'Sass' ),

--- a/dist/blocks.style.build.css
+++ b/dist/blocks.style.build.css
@@ -584,6 +584,10 @@
     background: #ffc334; }
   .wp-block-advanced-gutenberg-blocks-code__lang.is-lang-jsx {
     background: #ffc334; }
+  .wp-block-advanced-gutenberg-blocks-code__lang.is-lang-json {
+    background: #7197cf; }
+  .wp-block-advanced-gutenberg-blocks-code__lang.is-lang-ts {
+    background: #e8b12c; }
   .wp-block-advanced-gutenberg-blocks-code__lang.is-lang-php {
     background: #4F5B93; }
   .wp-block-advanced-gutenberg-blocks-code__lang.is-lang-xml {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js & npm run pot-to-php",
-    "pot-to-php": "./bin/pot-to-php.js languages/agb.pot languages/agb.php advanced-gutenberg-blocks"
+    "pot-to-php": "node ./bin/pot-to-php.js languages/agb.pot languages/agb.php advanced-gutenberg-blocks"
   },
   "dependencies": {
     "autoprefixer": "^7.2.4",

--- a/public/templates/code.php
+++ b/public/templates/code.php
@@ -14,7 +14,7 @@
   ><?php echo esc_html( $source ); ?></textarea>
   <script>
     CodeMirror.fromTextArea( document.getElementById('codemirror-<?php echo $rand; ?>'), {
-      mode: '<?php echo $lang_mode; ?>',
+      mode: '<?php echo $lang_mime ?: $lang_mode; ?>',
       readOnly: true,
       theme: '<?php echo $theme; ?>', 
       lineNumbers: <?php echo ( $showLines ) ? 'true' : 'false'; ?>,

--- a/src/blocks/code/style.scss
+++ b/src/blocks/code/style.scss
@@ -42,6 +42,8 @@
 
   &.is-lang-js     { background: #ffc334; }
   &.is-lang-jsx    { background: #ffc334; }
+  &.is-lang-json   { background: #7197cf; }
+  &.is-lang-ts     { background: #e8b12c; }
   &.is-lang-php    { background: #4F5B93; }
   &.is-lang-xml    { background: #F16529; }
   &.is-lang-html   { background: #F16529; }


### PR DESCRIPTION
I have added support for two new languages (specializations of *JavaScript*): *TypeScript* and *JSON*
They are listed in the [CodeMirror documentation](https://codemirror.net/mode/javascript/index.html)

I also added a mechanism to provide MIME for a language according to the documentation, and therefore making adding further languages/specializations very easy.

By the way I discovered that the `pot-to-php` script failed to start and I fixed it.