### PR TITLE
Fixed path to the translations and displaying of the Code block

### DIFF
--- a/classes/AdvancedGutenbergBlocks.php
+++ b/classes/AdvancedGutenbergBlocks.php
@@ -59,6 +59,9 @@ class AdvancedGutenbergBlocks {
 		// Load text domain
 		add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
 
+		// Exclude Code from wptexturize()
+		add_filter('no_texturize_tags', array($this, 'add_not_texturized_tags'));
+
 		// Plugin path
 		$path = plugin_dir_path( __DIR__ );
 
@@ -153,5 +156,11 @@ class AdvancedGutenbergBlocks {
 
 	public function load_textdomain() {
 	  load_plugin_textdomain( 'advanced-gutenberg-blocks', false, 'advanced-gutenberg-blocks/languages' );
+	}
+
+
+	public function add_not_texturized_tags($tags) {
+		$tags[] = 'textarea';
+		return $tags;
 	}
 }

--- a/classes/AdvancedGutenbergBlocks.php
+++ b/classes/AdvancedGutenbergBlocks.php
@@ -152,6 +152,6 @@ class AdvancedGutenbergBlocks {
 	 */
 
 	public function load_textdomain() {
-	  load_plugin_textdomain( 'advanced-gutenberg-blocks', false, plugin_dir_path( __DIR__ ) . '/languages' );
+	  load_plugin_textdomain( 'advanced-gutenberg-blocks', false, 'advanced-gutenberg-blocks/languages' );
 	}
 }


### PR DESCRIPTION
1. The path to the translations in `load_textdomain()` was incorrect.
The Code block joined two dashes `--` into one em dash or en dash. This caused source codes to display incorrectly, e.g. for `git checkout -- .`.