### PR TITLE
Table of Contents - expand entities and hide tags

### DIFF
--- a/src/blocks/summary/item.js
+++ b/src/blocks/summary/item.js
@@ -22,10 +22,31 @@ export default class Item extends Component {
        )
      } )
     }
-    
+
+    // (C) https://stackoverflow.com/a/9609450/1454656
+    const decodeEntities = (function() {
+      // this prevents any overhead from creating the object each time
+      const element = document.createElement('div');
+
+      function decodeHTMLEntities (str) {
+        if (str && typeof str === 'string') {
+          // strip script/html tags
+          str = str.replace(/<script[^>]*>([\S\s]*?)<\/script>/gmi, '');
+          str = str.replace(/<\/?\w(?:[^"'>]|"[^"]*"|'[^']*')*>/gmi, '');
+          element.innerHTML = str;
+          str = element.textContent;
+          element.textContent = '';
+        }
+
+        return str;
+      }
+
+      return decodeHTMLEntities;
+    })();
+
     const markup = ordered ? <ol>{subItems}</ol> : <ul>{subItems}</ul>
     const link = '#' + heading.data.slug
-    const content = heading.data.attributes.content.replace(/[&]nbsp[;]/gi, ' ' )
+    const content = decodeEntities(heading.data.attributes.content);
 
     return (
       <li key={heading.data.clientId}>

--- a/src/blocks/summary/list.js
+++ b/src/blocks/summary/list.js
@@ -27,9 +27,10 @@ export default class List extends Component {
 
         // Define anchor slug
         let slug = block.attributes.content.toString().toLowerCase()
-          .replace(/[&]nbsp[;]/gi, '-' )                  // Replace inseccable spaces
+          .replace(/[&]nbsp[;]/gi, '-')                   // Replace inseccable spaces
           .replace(/\s+/g, '-')                           // Replace spaces with -
-          .replace( /[&\/\\#,!+()$~%.'":*?<>{}]/g, '' )   // Remove special chars
+          .replace(/<[^<>]+>/g, '')                       // Remove tags
+          .replace(/[&\/\\#,!+()$~%.'":*?<>{}]/g, '')     // Remove special chars
           .replace(/\-\-+/g, '-')                         // Replace multiple - with single -
           .replace(/^-+/, '')                             // Trim - from start of text
           .replace(/-+$/, '');                            // Trim - from end of text


### PR DESCRIPTION
Previously TOC would display `&gt;` and `&amp;` instead of `>` and `&`.
It would also display `<b>Bold</b> header` instead of `Bold header`.
Similarly, the ID would contain tag names.
I fixed both behaviors.